### PR TITLE
Bugfix: don’t throw error if header is undefined

### DIFF
--- a/src/filters/current-page.js
+++ b/src/filters/current-page.js
@@ -8,7 +8,7 @@ import { currentPage as getCurrentPage } from '@x-govuk/govuk-eleventy-plugin/fi
  * @returns {Array} Header items
  */
 export function currentPage(header, pageUrl) {
-  if (!header.navigation?.items) {
+  if (!header || !header.navigation?.items) {
     return header
   }
 

--- a/test/filters/current-page.js
+++ b/test/filters/current-page.js
@@ -43,4 +43,16 @@ describe('currentPage filter', () => {
       { text: 'Styles 2', href: '/styles-2', active: false }
     ])
   })
+
+  it('Returns an empty object if header doesn’t contain navigation', () => {
+    const result = currentPage({}, '/')
+
+    assert.deepEqual(result, {})
+  })
+
+  it('Returns undefined if header is undefined', () => {
+    const result = currentPage(undefined, '/')
+
+    assert.deepEqual(result, undefined)
+  })
 })


### PR DESCRIPTION
Fixes #6.