### PR TITLE
Fix bug with tags not using slugify

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ export async function nhsukEleventyPlugin(eleventyConfig, pluginOptions = {}) {
 
     eleventyConfig.addTemplate(
       'tag.11ty.js',
-      new TagTemplate({...options.templates.tags, slugify})
+      new TagTemplate({ ...options.templates.tags, slugify })
     )
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ export async function nhsukEleventyPlugin(eleventyConfig, pluginOptions = {}) {
 
     eleventyConfig.addTemplate(
       'tag.11ty.js',
-      new TagTemplate(options.templates.tags, slugify)
+      new TagTemplate({...options.templates.tags, slugify})
     )
   }
 


### PR DESCRIPTION
Fixes #9.

This was caused by the `TagTemplate` being initialised with the slugify function as the second argument (which was then ignored), rather than being initialised with a single argument containing a object that includes the slugify function.

Took me a while to trace this one down!