### PR TITLE
Reducing heading font size and spacing in document list

### DIFF
--- a/src/components/_index.scss
+++ b/src/components/_index.scss
@@ -1,3 +1,4 @@
+@forward "card";
 @forward "code";
 @forward "contents-list";
 @forward "footnotes-list";

--- a/src/components/card/_index.scss
+++ b/src/components/card/_index.scss
@@ -1,0 +1,13 @@
+@use "../../vendor/nhsuk-frontend" as *;
+
+@include nhsuk-exports("nhsuk-eleventy-plugin/components/card") {
+
+  .nhsuk-card-group__item .app-card--reduced-spacing {
+    margin-bottom: nhsuk-spacing(4);
+  }
+
+  .app-card--reduced-spacing .nhsuk-card__content {
+    padding-bottom: nhsuk-spacing(4);
+  }
+
+}

--- a/src/components/card/_index.scss
+++ b/src/components/card/_index.scss
@@ -1,7 +1,6 @@
 @use "../../vendor/nhsuk-frontend" as *;
 
 @include nhsuk-exports("nhsuk-eleventy-plugin/components/card") {
-
   .nhsuk-card-group__item .app-card--reduced-spacing {
     margin-bottom: nhsuk-spacing(4);
   }
@@ -9,5 +8,4 @@
   .app-card--reduced-spacing .nhsuk-card__content {
     padding-bottom: nhsuk-spacing(4);
   }
-
 }

--- a/src/components/document-list/template.njk
+++ b/src/components/document-list/template.njk
@@ -8,10 +8,11 @@
       {{ nhsukCard({
         secondary: true,
         heading: item.heading,
-        headingClasses: params.headingClasses or "nhsuk-u-font-size-26" + (" nhsuk-u-margin-bottom-2" if item.descriptionHtml else ""),
+        headingClasses: params.headingClasses or "nhsuk-u-font-size-22" + (" nhsuk-u-margin-bottom-2" if item.descriptionHtml else ""),
         headingLevel: params.headingLevel or 2,
         href: item.href,
-        descriptionHtml: item.descriptionHtml
+        descriptionHtml: item.descriptionHtml,
+        classes: "app-card--reduced-spacing"
       }) | indent(6) }}
     </li>
   {% endfor %}


### PR DESCRIPTION
The collection page has quite a lot of whitespace and the linked headings are quite big compared to [our existing design history list pages](https://design-history.prevention-services.nhs.uk/record-a-vaccination/).

This reduces the spacing and the font size.

| Before | After |
|--------|-------|
| <img width="2164" height="3252" alt="x-govuk github io_nhsuk-eleventy-plugin_example_collection_" src="https://github.com/user-attachments/assets/2ef0f0eb-e463-414c-9d63-41d2deb8a19b" /> | <img width="2164" height="3044" alt="localhost_8080_example_collection_" src="https://github.com/user-attachments/assets/445a47d9-ea9f-4235-84d3-821d83d97bb3" /> |

