### PR TITLE
Add support for Markdown alerts

### DIFF
--- a/example/markdown.md
+++ b/example/markdown.md
@@ -63,6 +63,8 @@ The rendered output looks like this:
 
 > No society can legitimately call itself civilised if a sick person is denied aid because of lack of means..
 
+Do not use blockquotes to emphasis context. Use [alerts](#alerts) instead.
+
 ### Blockquotes with multiple paragraphs
 
 Blockquotes can contain multiple paragraphs. Add a `>` on the blank lines between the paragraphs.
@@ -94,6 +96,80 @@ The rendered output looks like this:
 > No society can legitimately call itself civilised if a sick person is denied aid because of lack of means..
 >
 > > Society becomes more wholesome, more serene, and spiritually healthier, if it knows that its citizens have at the back of their consciousness the knowledge that not only themselves, but all their fellows, have access, when ill, to the best that medical care can provide.
+
+## Alerts
+
+Alerts, based on the blockquote syntax, can be used emphasise critical information. [On GitHub they are displayed with distinctive colors and icons](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts), while pages rendered by the plugin use equivalent components from the NHS design system.
+
+### Note and tip alerts
+
+Note and tip alerts are rendered as [inset text](https://service-manual.nhs.uk/design-system/components/inset-text):
+
+```markdown
+> [!NOTE]
+> Highlights information that users should take into account, even when skimming.
+
+> [!TIP]
+> Optional information to help a user be more successful.
+```
+
+The rendered output looks like this:
+
+> [!NOTE]
+> Highlights information that users should take into account, even when skimming.
+
+> [!TIP]
+> Optional information to help a user be more successful.
+
+You can also include a title:
+
+```markdown
+> [!NOTE] Reporting side effects
+> You can report any suspected side effect to the [UK safety scheme](https://yellowcard.mhra.gov.uk/).
+```
+
+The rendered output looks like this:
+
+> [!NOTE] Reporting side effects
+> You can report any suspected side effect to the [UK safety scheme](https://yellowcard.mhra.gov.uk/).
+
+### Important, warning and caution alerts
+
+Important, warning and caution alerts are rendered as [warning callouts](https://service-manual.nhs.uk/design-system/components/warning-callout):
+
+```markdown
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+```
+
+The rendered output looks like this:
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+
+If you include a title, this will be shown in the heading instead of the alert type:
+
+```markdown
+> [!WARNING] School, nursery or work
+> Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.
+```
+
+The rendered output looks like this:
+
+> [!WARNING] School, nursery or work
+> Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.
 
 ## Lists
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "markdown-it-attrs": "^4.3.1",
         "markdown-it-deflist": "^3.0.0",
         "markdown-it-footnote": "^4.0.0",
+        "markdown-it-github-alerts": "^1.0.0",
         "markdown-it-govuk": "^0.6.0",
         "markdown-it-image-figures": "^2.0.0",
         "markdown-it-ins": "^4.0.0",
@@ -8028,6 +8029,18 @@
       "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
       "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==",
       "license": "MIT"
+    },
+    "node_modules/markdown-it-github-alerts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-github-alerts/-/markdown-it-github-alerts-1.0.0.tgz",
+      "integrity": "sha512-RU3cbB/ewujrDpYNdyabvp4CscZ5J/3D71NWbJW+JSA0nplfutIXDMCwtGWlMLwzgBDAYkFMvYGkigq8nWOVdA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "markdown-it": ">= 13.0.0"
+      }
     },
     "node_modules/markdown-it-govuk": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "markdown-it-attrs": "^4.3.1",
     "markdown-it-deflist": "^3.0.0",
     "markdown-it-footnote": "^4.0.0",
+    "markdown-it-github-alerts": "^1.0.0",
     "markdown-it-govuk": "^0.6.0",
     "markdown-it-image-figures": "^2.0.0",
     "markdown-it-ins": "^4.0.0",

--- a/src/markdown-it.js
+++ b/src/markdown-it.js
@@ -5,6 +5,7 @@ import markdownItAnchor from 'markdown-it-anchor'
 import markdownItAttrs from 'markdown-it-attrs'
 import markdownItDeflist from 'markdown-it-deflist'
 import markdownItFootnote from 'markdown-it-footnote'
+import MarkdownItGitHubAlerts from 'markdown-it-github-alerts'
 import markdownItGovuk from 'markdown-it-govuk'
 import highlight from 'markdown-it-govuk/highlight'
 import markdownItImageFigures from 'markdown-it-image-figures'
@@ -14,6 +15,7 @@ import markdownItSub from 'markdown-it-sub'
 import markdownItSup from 'markdown-it-sup'
 import markdownItTableOfContents from 'markdown-it-table-of-contents'
 
+import { alertRules } from './markdown-it/alert.js'
 import { defListRules } from './markdown-it/deflist.js'
 import { figureRules } from './markdown-it/figure.js'
 import { footnotesRules } from './markdown-it/footnote.js'
@@ -56,6 +58,10 @@ export function md(options = {}) {
     .use(defListRules)
     .use(markdownItFootnote)
     .use(footnotesRules)
+    .use(MarkdownItGitHubAlerts, {
+      classPrefix: 'nhsuk-inset-text'
+    })
+    .use(alertRules)
     .use(markdownItIns)
     .use(markdownItImageFigures, {
       classes: 'nhsuk-image__img',

--- a/src/markdown-it/alert.js
+++ b/src/markdown-it/alert.js
@@ -1,0 +1,36 @@
+/**
+ * Render a GitHub-style alert
+ *
+ * @param {Function} md - markdown-it instance
+ */
+export function alertRules(md) {
+  const { rules } = md.renderer
+
+  rules.alert_open = function (tokens, idx) {
+    const { title, type } = tokens[idx].meta
+
+    const visuallyHiddenTitle = type.charAt(0).toUpperCase() + type.slice(1)
+    const hasCustomTitle = title !== visuallyHiddenTitle
+
+    if (['caution', 'important', 'warning'].includes(type)) {
+      let html = `<div class="nhsuk-warning-callout app-warning-callout--${type}">`
+
+      // Warning callout always shows a heading, either a custom title,
+      // else the type of alert
+      html += hasCustomTitle
+        ? `<h3 class="nhsuk-warning-callout__label"><span class="nhsuk-u-visually-hidden">${visuallyHiddenTitle}: </span>${title}</h3>`
+        : `<h3 class="nhsuk-warning-callout__label">${visuallyHiddenTitle}</h3>`
+
+      return html
+    }
+
+    let html = `<div class="nhsuk-inset-text app-inset-text--${type}">`
+
+    // Inset text only shows a heading if there is a custom title
+    html += hasCustomTitle
+      ? `<h3 class="nhsuk-heading-m"><span class="nhsuk-u-visually-hidden">${visuallyHiddenTitle}: </span>${title}</h3>`
+      : `<span class="nhsuk-u-visually-hidden">${visuallyHiddenTitle}: </span>`
+
+    return html
+  }
+}

--- a/src/vendor/nhsuk-frontend/components/_index.scss
+++ b/src/vendor/nhsuk-frontend/components/_index.scss
@@ -12,3 +12,4 @@
 @forward "pkg:nhsuk-frontend/dist/nhsuk/components/skip-link";
 @forward "pkg:nhsuk-frontend/dist/nhsuk/components/tables";
 @forward "pkg:nhsuk-frontend/dist/nhsuk/components/tag";
+@forward "pkg:nhsuk-frontend/dist/nhsuk/components/warning-callout";

--- a/test/markdown-it.js
+++ b/test/markdown-it.js
@@ -23,6 +23,42 @@ describe('markdown-it', () => {
     )
   })
 
+  it('Renders a note alert as inset text', () => {
+    const result = md().render('> [!NOTE]\n> Text')
+
+    assert.equal(
+      result,
+      `<div class="nhsuk-inset-text app-inset-text--note"><span class="nhsuk-u-visually-hidden">Note: </span><p class="nhsuk-body">Text</p>\n</div>\n`
+    )
+  })
+
+  it('Renders a note alert with title as inset text with heading', () => {
+    const result = md().render('> [!NOTE] Heading\n> Text')
+
+    assert.equal(
+      result,
+      `<div class="nhsuk-inset-text app-inset-text--note"><h3 class="nhsuk-heading-m"><span class="nhsuk-u-visually-hidden">Note: </span>Heading</h3><p class="nhsuk-body">Text</p>\n</div>\n`
+    )
+  })
+
+  it('Renders an important alert as a warning callout', () => {
+    const result = md().render('> [!IMPORTANT]\n> Text')
+
+    assert.equal(
+      result,
+      `<div class="nhsuk-warning-callout app-warning-callout--important"><h3 class="nhsuk-warning-callout__label">Important</h3><p class="nhsuk-body">Text</p>\n</div>\n`
+    )
+  })
+
+  it('Renders an important alert with title as warning callout with heading', () => {
+    const result = md().render('> [!IMPORTANT] Heading\n> Text')
+
+    assert.equal(
+      result,
+      `<div class="nhsuk-warning-callout app-warning-callout--important"><h3 class="nhsuk-warning-callout__label"><span class="nhsuk-u-visually-hidden">Important: </span>Heading</h3><p class="nhsuk-body">Text</p>\n</div>\n`
+    )
+  })
+
   it('Renders a definition list', () => {
     const result = md().render('Term\n: Definition')
 


### PR DESCRIPTION
This PR solves 3 issues:

1. There is no way to render warning callouts.

2. There is no way to render inset text. Although it may be tempting to use the blockquote syntax, this is rarely the correct markup for such content.

3. GitHub alerts in Markdown content will be rendered as blockquotes (again, using the incorrect markup) and show the alert type as text:

    <img width="650" height="165" alt="Screenshot of alert rendered as a blockquote." src="https://github.com/user-attachments/assets/24f69693-f03b-4335-94bb-c9f0f697d5ad" />

This PR supports [the 5 different alert types](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts), and renders them using the equivalent components from the NHS design system:

- Note and tip alerts: Inset text
- Important, warning and caution alerts: Warning callout
