### PR TITLE
Allow plugin to set Markdown options

### DIFF
--- a/docs/get-started/options.md
+++ b/docs/get-started/options.md
@@ -28,12 +28,12 @@ export default function(eleventyConfig) {
 | --------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | footer                | object            | Options for [footer component](https://service-manual.nhs.uk/design-system/components/footer)                                                                                |
 | header                | object            | Options for [header component](https://service-manual.nhs.uk/design-system/components/header)                                                                                |
-| headingPermalinks     | boolean           | Add links to headings, making it easier to share sections of a page (default is `false`)                                                                                     |
 | homeKey               | string            | First item in pagination and key to use when referring to the home page for [`eleventyNavigation.parent`](https://www.11ty.dev/docs/plugins/navigation/) (default is `Home`) |
 | icons                 | object            | Override NHS.UK site icons                                                                                                                                                   |
 | icons.mask            | string or boolean | Override NHS.UK SVG mask icon. Use `false` to not include a mask icon.                                                                                                       |
 | icons.shortcut        | string or boolean | Override NHS.UK favicon. Use `false` to not include a favicon.                                                                                                               |
 | icons.touch           | string or boolean | Override NHS.UK touch icon. Use `false` to not include a touch icon.                                                                                                         |
+| markdown              | object            | Options for [Markdown](#options-for-markdown)                                                                                                                                |
 | opengraphImageUrl     | string            | URL for default Open Graph share image                                                                                                                                       |
 | showBreadcrumbs       | boolean           | Show breadcrumb navigation (default is `true` for nested pages)                                                                                                              |
 | stylesheets           | array             | Stylesheets to load instead of default application styles                                                                                                                    |
@@ -46,3 +46,12 @@ export default function(eleventyConfig) {
 | themeColor            | string            | Browser theme colour. Must be a hex value (default is `#005eb8`)                                                                                                             |
 | titleSuffix           | string            | Value to show at the end of the document title (default is `NHS`)                                                                                                            |
 | url                   | string            | The URL of your website. Optional, but required to have valid canonical URLs in Open Graph meta data.                                                                        |
+
+### Options for Markdown
+
+Alongside [options for markdown-it](https://markdown-it.github.io/markdown-it/#MarkdownIt.new), you can also set the following options:
+
+| Name              | Type    | Description                                                                              |
+| ----------------- | ------- | ---------------------------------------------------------------------------------------- |
+| headingPermalinks | boolean | Add links to headings, making it easier to share sections of a page (default is `false`) |
+| headingsStartWith | string  | Heading size to use for the top-level heading, `xl` or `l` (default is `xl`)             |

--- a/src/data/options.js
+++ b/src/data/options.js
@@ -12,6 +12,10 @@ const defaults = {
     shortcut: '/assets/images/favicon.ico',
     touch: '/assets/images/nhsuk-icon-180.png'
   },
+  markdown: {
+    headingPermalinks: false,
+    headingsStartWith: 'xl'
+  },
   opengraphImageUrl: '/assets/images/nhsuk-opengraph-image.png',
   stylesheets: [],
   titleSuffix: 'NHS',
@@ -44,6 +48,18 @@ export function defaultPluginOptions(options, pathPrefix) {
   if (options.templates?.feed) {
     // Add _feedPath to enable feed to be linked to from page head
     options._feedPath = options.templates?.feed?.permalink || '/feed.xml'
+  }
+
+  // Show message if using deprecated headingPermalinks option
+  if (options?.headingPermalinks) {
+    console.warn(
+      'The `headingPermalinks` option is deprecated and will be removed in a future version. Use `markdown.headingPermalinks` option instead.'
+    )
+
+    options.markdown = {
+      headingPermalinks: options.headingPermalinks,
+      ...options.markdown
+    }
   }
 
   return deepmerge(defaults, options)

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ export async function nhsukEleventyPlugin(eleventyConfig, pluginOptions = {}) {
   const options = defaultPluginOptions(pluginOptions, pathPrefix)
 
   // Libraries
-  eleventyConfig.setLibrary('md', md(options))
+  eleventyConfig.setLibrary('md', md(options.markdown))
   eleventyConfig.setLibrary('njk', nunjucksConfig(eleventyConfig))
 
   // Collections

--- a/src/markdown-it.js
+++ b/src/markdown-it.js
@@ -26,27 +26,28 @@ import { tableRules } from './markdown-it/table.js'
  * Configure markdown-it
  *
  * @see {@link https://markdown-it.github.io/markdown-it/}
- * @param {object} [options] - Plugin options
+ * @param {object} [markdownOptions] - Plugin Markdown options
  * @returns {Function} markdown-it instance
  */
-export function md(options = {}) {
+export function md(markdownOptions = {}) {
   const opts = {
     breaks: true,
     highlight,
     html: true,
     linkify: false,
-    typographer: true
+    typographer: true,
+    ...markdownOptions
   }
 
   const md = new MarkdownIt(opts)
     .use(markdownItGovuk, {
       brand: 'nhsuk',
       calvert: true,
-      headingsStartWith: 'xl'
+      headingsStartWith: markdownOptions.headingsStartWith
     })
     .use(markdownItAbbr)
     .use(markdownItAnchor, {
-      permalink: options.headingPermalinks
+      permalink: markdownOptions.headingPermalinks
         ? markdownItAnchor.permalink.headerLink({
             class: 'app-link--heading',
             safariReaderFix: true


### PR DESCRIPTION
Right now, changing the default starting heading size takes a bit of fiddling, using 11ty’s `amendLibrary` method and making sure to pass in the same options that this plugin does behind the scenes:

```js
import markdownItGovuk from "markdown-it-govuk";

export default function (eleventyConfig) {
  eleventyConfig.amendLibrary("md", (md) =>
    md.use(markdownItGovuk, {
      brand: "nhsuk",
      calvert: true,
      headingsStartWith: "l",
    })
  );
}
```

It’s not easy to pass options to `markdown-it` either; again, you’d need to use 11ty’s `amendLibrary` method to do so.

This PR allows authors to configure `markdown-it` (and certain `markdown-it-govuk` and other `markdown-it` plugin) options via a new `markdown` options object.

It also moves the `headingPermalinks` option to `markdown.headingPermalinks` (and adds a deprecation notice).

@milkshakeuk Was thinking of doing much the same for the GOV.UK Eleventy Plugin, so that we can pass in the `govspeak` option once it lands in `markdown-it-govuk`.