### PR TITLE
Add caption option to cards in list views

### DIFF
--- a/example/_data/posts.js
+++ b/example/_data/posts.js
@@ -1,5 +1,6 @@
 export default [
   {
+    caption: 'Digital health and social care',
     href: '#',
     title: 'Why should we build services using a design system?',
     date: '2022-06-08',
@@ -7,6 +8,7 @@ export default [
       'Conor Rohan, Assurance Lead, Department of Health and Social Care, explains why we use the NHS.UK and GOV.UK design systems and which one to use.'
   },
   {
+    caption: 'NHS Digital Transformation Blog',
     href: '#',
     title: '(Re)using the right tools for the job',
     date: '2022-05-07',
@@ -14,6 +16,7 @@ export default [
       'Shan Rahulan, Director of Platforms – Core Services, argues that we should not try to reinvent the wheel every time we build a product.'
   },
   {
+    caption: 'NHS Digital Design Matters Blog',
     href: '#',
     title: 'How a 20-year-old standard is still relevant today',
     date: '2022-03-08',
@@ -21,6 +24,7 @@ export default [
       'Tero Väänänen says BS EN ISO 9241-210 remains a guiding star for human-centred design. It’s the foundation to our own NHS service standard and the GOV.UK service standard.'
   },
   {
+    caption: 'Medium',
     href: '#',
     title: 'Encouraging a community to contribute to a design system',
     date: '2021-05-21',
@@ -28,6 +32,7 @@ export default [
       'Co-authored by Henry Cookson (user research) and Tosin Balogun (interaction design), user centred design (UCD) trainees who worked on the service manual team.'
   },
   {
+    caption: 'NHS Digital Design Matters Blog',
     href: '#',
     title: '10 ways the NHS digital service manual can help you',
     date: '2020-11-12',

--- a/src/components/document-list/template.njk
+++ b/src/components/document-list/template.njk
@@ -4,10 +4,21 @@
 {% if params.items.length > 0 %}
   <ol class="nhsuk-grid-row nhsuk-card-group{%- if params.classes %} {{ params.classes }}{% endif %}">
   {% for item in params.items | itemsFromCollection %}
+
+    {% if item.caption %}
+      {% set headingHtml %}
+        <div class="nhsuk-caption-m">{{ item.caption }}</div>
+        <h2 class="nhsuk-card__heading {{ params.headingClasses or "nhsuk-u-font-size-22" + (" nhsuk-u-margin-bottom-2" if item.descriptionHtml else "") }}">
+          <a class="nhsuk-card__link" href="{{ item.href }}">{{ item.heading }}</a>
+        </h2>
+      {% endset %}
+    {% endif %}
+
     <li class="nhsuk-grid-column-full nhsuk-card-group__item">
       {{ nhsukCard({
         secondary: true,
-        heading: item.heading,
+        heading: item.heading if not item.caption,
+        headingHtml: headingHtml if item.caption,
         headingClasses: params.headingClasses or "nhsuk-u-font-size-22" + (" nhsuk-u-margin-bottom-2" if item.descriptionHtml else ""),
         headingLevel: params.headingLevel or 2,
         href: item.href,

--- a/src/filters/items-from-collection.js
+++ b/src/filters/items-from-collection.js
@@ -57,6 +57,7 @@ export function itemsFromCollection(array, n) {
       return {
         href: item.url,
         date: item.data.date,
+        caption: item.data.caption,
         title: item.data.title,
         description: item.data.description,
         image: item.data.image
@@ -66,6 +67,7 @@ export function itemsFromCollection(array, n) {
 
   array = array.map((item) => ({
     href: item.href,
+    ...(item.caption && { caption: item.caption }),
     heading: smart(item.title),
     descriptionHtml: getDescriptionHtml(item),
     ...(item.image && { imgURL: item.image.src }),


### PR DESCRIPTION
This can be useful if you need to set a bit more context for each item (eg they come from different sources).

For design history sites with multiple teams, this could be used on the tag views or an `/all` page which intermingles posts from different teams.

See https://github.com/NHSDigital/prevention-services-design-history/issues/279

## Screenshot

<img width="2056" height="3045" alt="localhost_8080_example_collection_" src="https://github.com/user-attachments/assets/defedb64-9f10-49ca-a44d-3b457f96a5be" />
