### PR TITLE
Don’t sort breadcrumb items

### DIFF
--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -12,7 +12,7 @@
 {% set pageCount = pagination.pages | length %}
 
 {# Navigation #}
-{% set breadcrumbItems = collections.all | eleventyNavigationBreadcrumb(eleventyNavigation.key, { includeSelf: includeInBreadcrumbs, allowMissing: true }) | itemsFromNavigation(page.url, options) if eleventyNavigation.key %}
+{% set breadcrumbItems = collections.all | eleventyNavigationBreadcrumb(eleventyNavigation.key, { includeSelf: includeInBreadcrumbs, allowMissing: true }) | itemsFromNavigation(page.url) if eleventyNavigation.key %}
 {% set showBreadcrumbs = options.showBreadcrumbs != false and breadcrumbItems | length > 0 %}
 
 {% from "nhsuk/components/breadcrumb/macro.njk" import breadcrumb as nhsukBreadcrumb %}


### PR DESCRIPTION
Fixes #62.

At some point the shape of `itemsFromNavigation` changed in the upstream `govuk-eleventy-plugin`, and for some reason `options` was being passed as the second value; this sets the `sort` param to `true` when for breadcrumbs it should be `false` (the default parameter value for `itemsFromNavigation`).