### PR TITLE
Add headingSize support for product pages

### DIFF
--- a/docs/layouts/product.md
+++ b/docs/layouts/product.md
@@ -26,7 +26,7 @@ In addition to [common front matter options](/layouts/front-matter-options), thi
 
 | Name             | Type   | Description                                                                    |
 | ---------------- | ------ | ------------------------------------------------------------------------------ |
-| headingSize      | string | Size for the heading - `"m"`, `"l` or `"xl`                                    |
+| headingSize      | string | Size for the heading - for example, `"m"`, `"l` or `"xl`                       |
 | headingClasses   | string | Classes to use for heading in masthead                                         |
 | startButton      | object | Start button. Appears below the title and any description.                     |
 | startButton.text | string | Text for the start button (default is `Get started`)                           |

--- a/docs/layouts/product.md
+++ b/docs/layouts/product.md
@@ -26,6 +26,7 @@ In addition to [common front matter options](/layouts/front-matter-options), thi
 
 | Name             | Type   | Description                                                                    |
 | ---------------- | ------ | ------------------------------------------------------------------------------ |
+| headingSize      | string | Size for the heading - `"m"`, `"l` or `"xl`  |
 | headingClasses   | string | Classes to use for heading in masthead                                         |
 | startButton      | object | Start button. Appears below the title and any description.                     |
 | startButton.text | string | Text for the start button (default is `Get started`)                           |

--- a/docs/layouts/product.md
+++ b/docs/layouts/product.md
@@ -26,7 +26,7 @@ In addition to [common front matter options](/layouts/front-matter-options), thi
 
 | Name             | Type   | Description                                                                    |
 | ---------------- | ------ | ------------------------------------------------------------------------------ |
-| headingSize      | string | Size for the heading - `"m"`, `"l` or `"xl`  |
+| headingSize      | string | Size for the heading - `"m"`, `"l` or `"xl`                                    |
 | headingClasses   | string | Classes to use for heading in masthead                                         |
 | startButton      | object | Start button. Appears below the title and any description.                     |
 | startButton.text | string | Text for the start button (default is `Get started`)                           |

--- a/example/index.md
+++ b/example/index.md
@@ -3,7 +3,7 @@ homepage: true
 layout: product
 title: Rapidly create HTML prototypes of NHS services
 description: Use prototypes to get valuable feedback and insights from user research or the people you work with.
-headingClasses: nhsuk-heading-l
+headingSize: l
 startButton:
   href: "#"
   text: Get started

--- a/src/components/hero/template.njk
+++ b/src/components/hero/template.njk
@@ -1,4 +1,26 @@
 {% from "nhsuk/components/button/macro.njk" import button as nhsukButton %}
+
+{%- set classNamesHeading = "nhsuk-hero__heading" -%}
+
+{%- if params.headingSize and
+  params.headingSize in ["xxs", "xs", "s", "m", "l", "xl"] and (
+    not params.headingClasses or (
+      not "nhsuk-heading-xxs" in params.headingClasses and
+      not "nhsuk-heading-xs" in params.headingClasses and
+      not "nhsuk-heading-s" in params.headingClasses and
+      not "nhsuk-heading-m" in params.headingClasses and
+      not "nhsuk-heading-l" in params.headingClasses and
+      not "nhsuk-heading-xl" in params.headingClasses
+    )
+  )
+%}
+  {% set classNamesHeading = classNamesHeading ~ " nhsuk-heading-" ~ params.headingSize %}
+{% endif %}
+
+{%- if params.headingClasses %}
+  {% set classNamesHeading = classNamesHeading ~ " " ~ params.headingClasses %}
+{% endif %}
+
 <div class="nhsuk-hero">
   <div class="nhsuk-width-container nhsuk-hero--border">
     <div class="nhsuk-grid-row">
@@ -10,7 +32,7 @@
           </span>
           {% endif %}
           {% if params.title %}
-          <h1 class="nhsuk-hero__heading{%- if params.headingClasses %} {{ params.headingClasses }}{% endif %}">
+          <h1 class="{{ classNamesHeading }}">
             {{- params.title | smart -}}
           </h1>
           {% endif %}

--- a/src/layouts/product.njk
+++ b/src/layouts/product.njk
@@ -4,6 +4,7 @@
   {{ appHero({
     caption: caption,
     title: title,
+    headingSize: headingSize,
     headingClasses: headingClasses,
     description: description,
     image: image,


### PR DESCRIPTION
This lets you more easily drop the heading size down from XL (default) to L. Follows the convention of recent changes in NHS frontend.

Code copied from [the Hero in NHS frontend](https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/nhsuk-frontend/src/nhsuk/components/hero/template.njk#L16-L33)

(Ideally we’d use that hero component directly, updating it to support this pattern, but that’s a whole other topic)