### PR TITLE
Use `template-with-imports.njk`

### DIFF
--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -32,9 +32,6 @@ For example, to show a message at the top of each page that uses the page layout
 {% raw %}{# Extend a plugin layout #}
 {% extends "layouts/page.njk" %}
 
-{# Load any NHS.UK frontend components #}
-{% from "nhsuk/components/inset-text/macro.njk" import insetText %}
-
 {# Override the `content` block #}
 {% block content %}
   {{ appDocumentHeader({

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -1,4 +1,4 @@
-{% extends "nhsuk/template.njk" %}
+{% extends "nhsuk/template-with-imports.njk" %}
 
 {% set themeColor = options.themeColor | default("#005eb8", true) -%}
 
@@ -14,12 +14,6 @@
 {# Navigation #}
 {% set breadcrumbItems = collections.all | eleventyNavigationBreadcrumb(eleventyNavigation.key, { includeSelf: includeInBreadcrumbs, allowMissing: true }) | itemsFromNavigation(page.url) if eleventyNavigation.key %}
 {% set showBreadcrumbs = options.showBreadcrumbs != false and breadcrumbItems | length > 0 %}
-
-{% from "nhsuk/components/breadcrumb/macro.njk" import breadcrumb as nhsukBreadcrumb %}
-{% from "nhsuk/components/footer/macro.njk" import footer as nhsukFooter %}
-{% from "nhsuk/components/header/macro.njk" import header as nhsukHeader %}
-{% from "nhsuk/components/images/macro.njk" import image as nhsukImage %}
-{% from "nhsuk/components/pagination/macro.njk" import pagination as nhsukPagination %}
 
 {% from "components/card-group/macro.njk" import appCardGroup with context %}
 {% from "components/document-header/macro.njk" import appDocumentHeader %}
@@ -65,15 +59,15 @@
 {% block header %}
 {% if options._searchIndexPath %}
 <app-search index="{{ options._searchIndexPath | htmlBaseUrl }}">
-  {{ nhsukHeader(options.header | currentPage(page.url)) }}
+  {{ header(options.header | currentPage(page.url)) }}
 </app-search>
 {% else %}
-  {{ nhsukHeader(options.header | currentPage(page.url)) }}
+  {{ header(options.header | currentPage(page.url)) }}
 {% endif %}
 {% endblock %}
 
 {% block footer %}
-  {{ nhsukFooter(options.footer) }}
+  {{ footer(options.footer) }}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/src/layouts/collection.njk
+++ b/src/layouts/collection.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block beforeContent %}
-  {{ nhsukBreadcrumb({
+  {{ breadcrumb({
     items: breadcrumbItems
   }) if showBreadcrumbs }}
 {% endblock %}
@@ -26,7 +26,7 @@
     items: pagination.items
   }) }}
 
-  {{ nhsukPagination({
+  {{ pagination({
     previous: {
       href: pagination.href.previous
     },

--- a/src/layouts/hub.njk
+++ b/src/layouts/hub.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block beforeContent %}
-  {{ nhsukBreadcrumb({
+  {{ breadcrumb({
     items: breadcrumbItems
   }) if showBreadcrumbs }}
 {% endblock %}

--- a/src/layouts/page.njk
+++ b/src/layouts/page.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block beforeContent %}
-  {{ nhsukBreadcrumb({
+  {{ breadcrumb({
     items: breadcrumbItems
   }) if showBreadcrumbs }}
 {% endblock %}
@@ -18,7 +18,7 @@
   {% if showPagination %}
     {% set previous = collections.navigation | eleventyNavigation(sectionKey or options.homeKey) | getPreviousNavigationItem(page.url) %}
     {% set next = collections.navigation | eleventyNavigation(sectionKey or options.homeKey) | getNextNavigationItem(page.url) %}
-    {{ nhsukPagination({
+    {{ pagination({
       classes: "nhsuk-u-reading-width",
       previousUrl: previous.url if previous,
       previousPage: previous.title if previous,

--- a/src/layouts/post.njk
+++ b/src/layouts/post.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block beforeContent %}
-  {{ nhsukBreadcrumb({
+  {{ breadcrumb({
     items: breadcrumbItems
   }) if showBreadcrumbs }}
 {% endblock %}
@@ -21,7 +21,7 @@
   }) }}
 
   {% call appProseScope() %}
-    {{ nhsukImage({
+    {{ image({
       classes: "app-image--full",
       src: image.src,
       alt: image.alt,
@@ -34,7 +34,7 @@
   {% if showPagination %}
     {% set previous = collections.navigation | eleventyNavigation(sectionKey or options.homeKey) | getPreviousNavigationItem(page.url) %}
     {% set next = collections.navigation | eleventyNavigation(sectionKey or options.homeKey) | getNextNavigationItem(page.url) %}
-    {{ nhsukPagination({
+    {{ pagination({
       classes: "nhsuk-u-reading-width",
       previousUrl: previous.url if previous,
       previousPage: previous.title if previous,

--- a/src/layouts/sub-navigation.njk
+++ b/src/layouts/sub-navigation.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block beforeContent %}
-  {{ nhsukBreadcrumb({
+  {{ breadcrumb({
     items: breadcrumbItems
   }) if showBreadcrumbs }}
 {% endblock %}
@@ -25,7 +25,7 @@
       {% if showPagination %}
         {% set previous = collections.navigation | eleventyNavigation(sectionKey or options.homeKey) | getPreviousNavigationItem(page.url) %}
         {% set next = collections.navigation | eleventyNavigation(sectionKey or options.homeKey) | getNextNavigationItem(page.url) %}
-        {{ nhsukPagination({
+        {{ pagination({
           classes: "nhsuk-u-reading-width",
           previousUrl: previous.url if previous,
           previousPage: previous.title if previous,

--- a/src/nunjucks.js
+++ b/src/nunjucks.js
@@ -35,7 +35,7 @@ export function nunjucksConfig(eleventyConfig) {
     ...(includes ? [path.join(input, includes)] : []),
     ...(layouts ? [path.join(input, layouts)] : []),
     input,
-    './node_modules/@x-govuk/nhsuk-eleventy-plugin/src',
+    'node_modules/@x-govuk/nhsuk-eleventy-plugin/src',
     'node_modules/nhsuk-frontend/dist/nhsuk/components',
     'node_modules/nhsuk-frontend/dist/nhsuk/macros',
     'node_modules/nhsuk-frontend/dist/nhsuk',

--- a/src/nunjucks.js
+++ b/src/nunjucks.js
@@ -36,7 +36,10 @@ export function nunjucksConfig(eleventyConfig) {
     ...(layouts ? [path.join(input, layouts)] : []),
     input,
     './node_modules/@x-govuk/nhsuk-eleventy-plugin/src',
-    './node_modules/nhsuk-frontend/dist'
+    'node_modules/nhsuk-frontend/dist/nhsuk/components',
+    'node_modules/nhsuk-frontend/dist/nhsuk/macros',
+    'node_modules/nhsuk-frontend/dist/nhsuk',
+    'node_modules/nhsuk-frontend/dist'
   ]
 
   /**


### PR DESCRIPTION
This saves having to manually import the required components in the base template.

Also means that you can add NHS components to custom layout templates without having to import them.