### PR TITLE
Add highlight support for all languages

### DIFF
--- a/src/markdown-it/highlight.js
+++ b/src/markdown-it/highlight.js
@@ -1,4 +1,12 @@
+import hljs from 'highlight.js'
 import { highlighter } from 'nhsuk-frontend/lib/highlighter/index.mjs'
+
+// Register all highlight.js languages
+for (const name of hljs.listLanguages()) {
+  if (!highlighter.getLanguage(name)) {
+    highlighter.registerLanguage(name, hljs.getLanguage(name).rawDefinition)
+  }
+}
 
 /**
  * Highlight code using highlight.js


### PR DESCRIPTION
Given that this is a statically built site, and could be used for documentation for a variety of languages, it makes sense to support syntax highlighting for all 192 that Highlight.js supports, rather than just [the subset](https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/nhsuk-frontend/src/nhsuk/lib/highlighter/languages/index.mjs#L4-L13) supported by nhsuk-frontend.

(In particular, we’ll need Swift and Kotlin support for the NHS app design system guidance site)