### PR TITLE
Fix for pagination conflict

### DIFF
--- a/src/data/eleventy-computed.js
+++ b/src/data/eleventy-computed.js
@@ -9,6 +9,9 @@ import {
  * @see {@link https://www.11ty.dev/docs/plugins/navigation/}
  */
 export const eleventyComputed = {
+  // Alias for Eleventy's pagination data to avoid naming conflict with the
+  // nhsuk-frontend `pagination` Nunjucks macro in template-with-imports.njk
+  paginationData: (data) => data.pagination,
   eleventyNavigation: {
     key: (data) => getNavigationKey(data),
     parent: (data) => getNavigationParent(data),

--- a/src/data/eleventy-computed.js
+++ b/src/data/eleventy-computed.js
@@ -11,7 +11,7 @@ import {
 export const eleventyComputed = {
   // Alias for Eleventy's pagination data to avoid naming conflict with the
   // nhsuk-frontend `pagination` Nunjucks macro in template-with-imports.njk
-  paginationData: (data) => data.pagination,
+  eleventyPagination: (data) => data.pagination,
   eleventyNavigation: {
     key: (data) => getNavigationKey(data),
     parent: (data) => getNavigationParent(data),

--- a/src/layouts/collection.njk
+++ b/src/layouts/collection.njk
@@ -23,18 +23,18 @@
 
   {{ appDocumentList({
     headingLevel: 3 if paginationHeading else 2,
-    items: pagination.items
+    items: paginationData.items
   }) }}
 
   {{ pagination({
     previous: {
-      href: pagination.href.previous
+      href: paginationData.href.previous
     },
     next: {
-      href: pagination.href.next
+      href: paginationData.href.next
     },
-    items: pagination | itemsFromPagination
-  }) if pagination.pages.length > 1 }}
+    items: paginationData | itemsFromPagination
+  }) if paginationData.pages.length > 1 }}
 
   {{ appRelated(related) if related }}
 {% endblock %}

--- a/src/layouts/collection.njk
+++ b/src/layouts/collection.njk
@@ -23,18 +23,18 @@
 
   {{ appDocumentList({
     headingLevel: 3 if paginationHeading else 2,
-    items: paginationData.items
+    items: eleventyPagination.items
   }) }}
 
   {{ pagination({
     previous: {
-      href: paginationData.href.previous
+      href: eleventyPagination.href.previous
     },
     next: {
-      href: paginationData.href.next
+      href: eleventyPagination.href.next
     },
-    items: paginationData | itemsFromPagination
-  }) if paginationData.pages.length > 1 }}
+    items: eleventyPagination | itemsFromPagination
+  }) if eleventyPagination.pages.length > 1 }}
 
   {{ appRelated(related) if related }}
 {% endblock %}


### PR DESCRIPTION
The pagination Nunjucks macro from NHS frontend was conflicting with the pagination object provided by Eleventy.

The fix is to alias the pagination object as `paginationData` so that it can be accessed by the layout.

Fixes #78