### PR TITLE
Fix naming collisions

### DIFF
--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -33,7 +33,7 @@ For example, to show a message at the top of each page that uses the page layout
 {% extends "layouts/page.njk" %}
 
 {# Load any NHS.UK frontend components #}
-{% from "inset-text/macro.njk" import insetText %}
+{% from "notification-banner/macro.njk" import notificationBanner %}
 
 {# Override the `content` block #}
 {% block content %}

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -35,6 +35,9 @@ For example, to show a message at the top of each page that uses the page layout
 {# Load any NHS.UK frontend components #}
 {% from "notification-banner/macro.njk" import notificationBanner %}
 
+{# If the component shares the same name as you’d like to use in front matter data, you can import it with a prefix #}
+{% from "tabs/macro.njk" import tabs as nhsukTabs %}
+
 {# Override the `content` block #}
 {% block content %}
   {{ appDocumentHeader({

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -32,6 +32,9 @@ For example, to show a message at the top of each page that uses the page layout
 {% raw %}{# Extend a plugin layout #}
 {% extends "layouts/page.njk" %}
 
+{# Load any NHS.UK frontend components #}
+{% from "inset-text/macro.njk" import insetText %}
+
 {# Override the `content` block #}
 {% block content %}
   {{ appDocumentHeader({

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "markdown-it-sub": "^2.0.0",
         "markdown-it-sup": "^2.0.0",
         "markdown-it-table-of-contents": "^1.2.0",
-        "nhsuk-frontend": "^10.5.2",
+        "nhsuk-frontend": "^10.6.0",
         "rollup": "^4.62.2",
         "sass": "^1.101.0"
       },
@@ -1424,9 +1424,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1446,9 +1443,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1470,9 +1464,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1492,9 +1483,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1516,9 +1504,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1538,9 +1523,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1839,9 +1821,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1854,9 +1833,6 @@
       "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1871,9 +1847,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1886,9 +1859,6 @@
       "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1903,9 +1873,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1918,9 +1885,6 @@
       "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1935,9 +1899,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1950,9 +1911,6 @@
       "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1967,9 +1925,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1982,9 +1937,6 @@
       "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1999,9 +1951,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2015,9 +1964,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2030,9 +1976,6 @@
       "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2776,9 +2719,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2793,9 +2733,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2810,9 +2747,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2827,9 +2761,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2844,9 +2775,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2861,9 +2789,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2878,9 +2803,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2895,9 +2817,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2912,9 +2831,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2929,9 +2845,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9881,9 +9794,9 @@
       }
     },
     "node_modules/nhsuk-frontend": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.5.2.tgz",
-      "integrity": "sha512-lTOmzSDJkEn8uhuEuj3NKAW5MYuG/5tqMRsp15An2oLKlpGEoEAoREp+tHYJ7DLOPDRp9Z/zmp6/pLea75ae1g==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.6.0.tgz",
+      "integrity": "sha512-ZhnQiK6q6C8d0nwwzYSI+dSPuvJMqVPPtCHCoQif75L2Y8QW4Im0Q76UvqrNWkPAkX/lV2W1QNbot27ej61+3g==",
       "license": "MIT",
       "engines": {
         "node": "^20.9.0 || ^22.11.0 || >= 24.11.0"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "markdown-it-sub": "^2.0.0",
     "markdown-it-sup": "^2.0.0",
     "markdown-it-table-of-contents": "^1.2.0",
-    "nhsuk-frontend": "^10.5.2",
+    "nhsuk-frontend": "^10.6.0",
     "rollup": "^4.62.2",
     "sass": "^1.101.0"
   },

--- a/src/data/eleventy-computed.js
+++ b/src/data/eleventy-computed.js
@@ -9,9 +9,6 @@ import {
  * @see {@link https://www.11ty.dev/docs/plugins/navigation/}
  */
 export const eleventyComputed = {
-  // Alias for Eleventy's pagination data to avoid naming conflict with the
-  // nhsuk-frontend `pagination` Nunjucks macro in template-with-imports.njk
-  eleventyPagination: (data) => data.pagination,
   eleventyNavigation: {
     key: (data) => getNavigationKey(data),
     parent: (data) => getNavigationParent(data),

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -1,4 +1,4 @@
-{% extends "nhsuk/template-with-imports.njk" %}
+{% extends "nhsuk/template.njk" %}
 
 {% set themeColor = options.themeColor | default("#005eb8", true) -%}
 
@@ -14,6 +14,13 @@
 {# Navigation #}
 {% set breadcrumbItems = collections.all | eleventyNavigationBreadcrumb(eleventyNavigation.key, { includeSelf: includeInBreadcrumbs, allowMissing: true }) | itemsFromNavigation(page.url) if eleventyNavigation.key %}
 {% set showBreadcrumbs = options.showBreadcrumbs != false and breadcrumbItems | length > 0 %}
+
+{# These components are imported from NHS.UK frontend with a prefix to avoid naming collisions with front matter data #}
+{% from "nhsuk/components/breadcrumb/macro.njk" import breadcrumb as nhsukBreadcrumb %}
+{% from "nhsuk/components/footer/macro.njk" import footer as nhsukFooter %}
+{% from "nhsuk/components/header/macro.njk" import header as nhsukHeader %}
+{% from "nhsuk/components/images/macro.njk" import image as nhsukImage %}
+{% from "nhsuk/components/pagination/macro.njk" import pagination as nhsukPagination %}
 
 {% from "components/card-group/macro.njk" import appCardGroup with context %}
 {% from "components/document-header/macro.njk" import appDocumentHeader %}
@@ -59,15 +66,15 @@
 {% block header %}
 {% if options._searchIndexPath %}
 <app-search index="{{ options._searchIndexPath | htmlBaseUrl }}">
-  {{ header(options.header | currentPage(page.url)) }}
+  {{ nhsukHeader(options.header | currentPage(page.url)) }}
 </app-search>
 {% else %}
-  {{ header(options.header | currentPage(page.url)) }}
+  {{ nhsukHeader(options.header | currentPage(page.url)) }}
 {% endif %}
 {% endblock %}
 
 {% block footer %}
-  {{ footer(options.footer) }}
+  {{ nhsukFooter(options.footer) }}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/src/layouts/collection.njk
+++ b/src/layouts/collection.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block beforeContent %}
-  {{ breadcrumb({
+  {{ nhsukBreadcrumb({
     items: breadcrumbItems
   }) if showBreadcrumbs }}
 {% endblock %}
@@ -26,7 +26,7 @@
     items: eleventyPagination.items
   }) }}
 
-  {{ pagination({
+  {{ nhsukPagination({
     previous: {
       href: eleventyPagination.href.previous
     },

--- a/src/layouts/hub.njk
+++ b/src/layouts/hub.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block beforeContent %}
-  {{ breadcrumb({
+  {{ nhsukBreadcrumb({
     items: breadcrumbItems
   }) if showBreadcrumbs }}
 {% endblock %}

--- a/src/layouts/page.njk
+++ b/src/layouts/page.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block beforeContent %}
-  {{ breadcrumb({
+  {{ nhsukBreadcrumb({
     items: breadcrumbItems
   }) if showBreadcrumbs }}
 {% endblock %}
@@ -18,7 +18,7 @@
   {% if showPagination %}
     {% set previous = collections.navigation | eleventyNavigation(sectionKey or options.homeKey) | getPreviousNavigationItem(page.url) %}
     {% set next = collections.navigation | eleventyNavigation(sectionKey or options.homeKey) | getNextNavigationItem(page.url) %}
-    {{ pagination({
+    {{ nhsukPagination({
       classes: "nhsuk-u-reading-width",
       previousUrl: previous.url if previous,
       previousPage: previous.title if previous,

--- a/src/layouts/post.njk
+++ b/src/layouts/post.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block beforeContent %}
-  {{ breadcrumb({
+  {{ nhsukBreadcrumb({
     items: breadcrumbItems
   }) if showBreadcrumbs }}
 {% endblock %}
@@ -21,7 +21,7 @@
   }) }}
 
   {% call appProseScope() %}
-    {{ image({
+    {{ nhsukImage({
       classes: "app-image--full",
       src: image.src,
       alt: image.alt,
@@ -34,7 +34,7 @@
   {% if showPagination %}
     {% set previous = collections.navigation | eleventyNavigation(sectionKey or options.homeKey) | getPreviousNavigationItem(page.url) %}
     {% set next = collections.navigation | eleventyNavigation(sectionKey or options.homeKey) | getNextNavigationItem(page.url) %}
-    {{ pagination({
+    {{ nhsukPagination({
       classes: "nhsuk-u-reading-width",
       previousUrl: previous.url if previous,
       previousPage: previous.title if previous,

--- a/src/layouts/sub-navigation.njk
+++ b/src/layouts/sub-navigation.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/base.njk" %}
 
 {% block beforeContent %}
-  {{ breadcrumb({
+  {{ nhsukBreadcrumb({
     items: breadcrumbItems
   }) if showBreadcrumbs }}
 {% endblock %}
@@ -25,7 +25,7 @@
       {% if showPagination %}
         {% set previous = collections.navigation | eleventyNavigation(sectionKey or options.homeKey) | getPreviousNavigationItem(page.url) %}
         {% set next = collections.navigation | eleventyNavigation(sectionKey or options.homeKey) | getNextNavigationItem(page.url) %}
-        {{ pagination({
+        {{ nhsukPagination({
           classes: "nhsuk-u-reading-width",
           previousUrl: previous.url if previous,
           previousPage: previous.title if previous,


### PR DESCRIPTION
In #75 we switched to using `template-with-imports.njk` from NHS.UK frontend, and whilst that’s useful, several of the NHS macro components share the same name as some common front matter data items used by this Eleventy plugin:

* `image`
* `pagination`
* `header`
* `footer`
* `breadcrumb`
* `caption` (added in v10.6)

#82 tried to avoid this by aliasing the frontmatter data with a prefix, but this isn’t ideal.

Instead, this reverts the changes and instead only imports the macros used in the layouts, adding an `nhsuk` prefix to avoid the collisions.

In any custom layouts or nunjucks pages, users will have to import any NHS.UK frontend macros used.

However this keeps addition of the Nunjucks view paths, so that you can do

```
{% from "inset-text/macro.njk" import insetText %}
```

as used in the NHS service manual examples, rather than the longer:

```
{% from "nhsuk/components/inset-text/macro.njk" import insetText %}
```

Fixes #81